### PR TITLE
Make the dynamic programming algorithm generic.

### DIFF
--- a/levenshtein/distances.go
+++ b/levenshtein/distances.go
@@ -1,0 +1,22 @@
+package levenshtein
+
+var DefaultLevenshtein []EditOperation = []EditOperation{
+	Match{},
+	Insertion{1},
+	Deletion{1},
+	Substitution{1},
+}
+
+var DefaultDamerau []EditOperation = []EditOperation{
+	Match{},
+	Insertion{1},
+	Deletion{1},
+	Substitution{1},
+	Transposition{1},
+}
+
+var DefaultLCS []EditOperation = []EditOperation{
+	Match{},
+	Insertion{1},
+	Deletion{1},
+}

--- a/levenshtein/levenshtein.go
+++ b/levenshtein/levenshtein.go
@@ -3,54 +3,13 @@ package levenshtein
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 )
 
-type EditOperation int
-
-const (
-	Ins = iota
-	Del
-	Sub
-	Match
-)
-
-type EditScript []EditOperation
-
-type MatchFunction func(rune, rune) bool
-
-type Options struct {
-	InsCost int
-	DelCost int
-	SubCost int
-	Matches MatchFunction
-}
-
-// DefaultOptions is the default options: insertion cost is 1, deletion cost is
-// 1, substitution cost is 2, and two runes match iff they are the same.
-var DefaultOptions Options = Options{
-	InsCost: 1,
-	DelCost: 1,
-	SubCost: 2,
-	Matches: func(sourceCharacter rune, targetCharacter rune) bool {
-		return sourceCharacter == targetCharacter
-	},
-}
-
-func (operation EditOperation) String() string {
-	if operation == Match {
-		return "match"
-	} else if operation == Ins {
-		return "ins"
-	} else if operation == Sub {
-		return "sub"
-	}
-	return "del"
-}
-
 // DistanceForStrings returns the edit distance between source and target.
-func DistanceForStrings(source []rune, target []rune, op Options) int {
-	return DistanceForMatrix(MatrixForStrings(source, target, op))
+func DistanceForStrings(source []rune, target []rune, ops []EditOperation) int {
+	return DistanceForMatrix(MatrixForStrings(source, target, ops))
 }
 
 // DistanceForMatrix reads the edit distance off the given Levenshtein matrix.
@@ -65,7 +24,7 @@ func DistanceForMatrix(matrix [][]int) int {
 // that it cannot only be used for reading of the edit distance between two
 // strings, but also e.g. to backtrace an edit script that provides an
 // alignment between the characters of both strings.
-func MatrixForStrings(source []rune, target []rune, op Options) [][]int {
+func MatrixForStrings(source []rune, target []rune, ops []EditOperation) [][]int {
 	// Make a 2-D matrix. Rows correspond to prefixes of source, columns to
 	// prefixes of target. Cells will contain edit distances.
 	// Cf. http://www.let.rug.nl/~kleiweg/lev/levenshtein.html
@@ -87,14 +46,14 @@ func MatrixForStrings(source []rune, target []rune, op Options) [][]int {
 	// (edit history, operation) pair with the lowest cost.
 	for i := 1; i < height; i++ {
 		for j := 1; j < width; j++ {
-			delCost := matrix[i-1][j] + op.DelCost
-			matchSubCost := matrix[i-1][j-1]
-			if !op.Matches(source[i-1], target[j-1]) {
-				matchSubCost += op.SubCost
+			lowestCost := math.MaxInt32
+			for _, op := range ops {
+				if cost, ok := op.Apply(source, target, matrix, i, j); ok && cost < lowestCost {
+					lowestCost = cost
+				}
 			}
-			insCost := matrix[i][j-1] + op.InsCost
-			matrix[i][j] = min(delCost, min(matchSubCost,
-				insCost))
+
+			matrix[i][j] = lowestCost
 		}
 	}
 	//LogMatrix(source, target, matrix)
@@ -103,15 +62,15 @@ func MatrixForStrings(source []rune, target []rune, op Options) [][]int {
 
 // EditScriptForStrings returns an optimal edit script to turn source into
 // target.
-func EditScriptForStrings(source []rune, target []rune, op Options) EditScript {
+func EditScriptForStrings(source []rune, target []rune, ops []EditOperation) EditScript {
 	return backtrace(len(source), len(target),
-		MatrixForStrings(source, target, op), op)
+		MatrixForStrings(source, target, ops), ops)
 }
 
 // EditScriptForMatrix returns an optimal edit script based on the given
 // Levenshtein matrix.
-func EditScriptForMatrix(matrix [][]int, op Options) EditScript {
-	return backtrace(len(matrix[0])-1, len(matrix)-1, matrix, op)
+func EditScriptForMatrix(matrix [][]int, ops []EditOperation) EditScript {
+	return backtrace(len(matrix[0])-1, len(matrix)-1, matrix, ops)
 }
 
 // WriteMatrix writes a visual representation of the given matrix for the given
@@ -123,13 +82,13 @@ func WriteMatrix(source []rune, target []rune, matrix [][]int, writer io.Writer)
 	}
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "  %2d", matrix[0][0])
-	for j, _ := range target {
+	for j := range target {
 		fmt.Fprintf(writer, " %2d", matrix[0][j+1])
 	}
 	fmt.Fprintf(writer, "\n")
 	for i, sourceRune := range source {
 		fmt.Fprintf(writer, "%c %2d", sourceRune, matrix[i+1][0])
-		for j, _ := range target {
+		for j := range target {
 			fmt.Fprintf(writer, " %2d", matrix[i+1][j+1])
 		}
 		fmt.Fprintf(writer, "\n")
@@ -143,20 +102,20 @@ func LogMatrix(source []rune, target []rune, matrix [][]int) {
 	WriteMatrix(source, target, matrix, os.Stderr)
 }
 
-func backtrace(i int, j int, matrix [][]int, op Options) EditScript {
-	if i > 0 && matrix[i-1][j]+op.DelCost == matrix[i][j] {
-		return append(backtrace(i-1, j, matrix, op), Del)
+func backtrace(i int, j int, matrix [][]int, ops []EditOperation) EditScript {
+	for _, op := range ops {
+		ib, jb := op.Backtrack(matrix, i, j)
+
+		if ib < 0 || jb < 0 {
+			continue
+		}
+
+		if cost, ok := op.Apply(nil, nil, matrix, ib, jb); ok && cost == matrix[i][j] {
+			return append(backtrace(ib, jb, matrix, ops), op)
+		}
 	}
-	if j > 0 && matrix[i][j-1]+op.InsCost == matrix[i][j] {
-		return append(backtrace(i, j-1, matrix, op), Ins)
-	}
-	if i > 0 && j > 0 && matrix[i-1][j-1]+op.SubCost == matrix[i][j] {
-		return append(backtrace(i-1, j-1, matrix, op), Sub)
-	}
-	if i > 0 && j > 0 && matrix[i-1][j-1] == matrix[i][j] {
-		return append(backtrace(i-1, j-1, matrix, op), Match)
-	}
-	return []EditOperation{}
+
+	return EditScript{}
 }
 
 func min(a int, b int) int {

--- a/levenshtein/levenshtein_test.go
+++ b/levenshtein/levenshtein_test.go
@@ -7,49 +7,58 @@ import (
 )
 
 var testCases = []struct {
-	source   string
-	target   string
-	distance int
+	source          string
+	target          string
+	distance        int
+	damerauDistance int
+	lcsDistance     int
 }{
-	{"", "a", 1},
-	{"a", "aa", 1},
-	{"a", "aaa", 2},
-	{"", "", 0},
-	{"a", "b", 2},
-	{"aaa", "aba", 2},
-	{"aaa", "ab", 3},
-	{"a", "a", 0},
-	{"ab", "ab", 0},
-	{"a", "", 1},
-	{"aa", "a", 1},
-	{"aaa", "a", 2},
+	{"", "a", 1, 1, 1},
+	{"a", "aa", 1, 1, 1},
+	{"a", "aaa", 2, 2, 2},
+	{"", "", 0, 0, 0},
+	{"a", "b", 1, 1, 2},
+	{"aaa", "aba", 1, 1, 2},
+	{"aaa", "ab", 2, 2, 3},
+	{"a", "a", 0, 0, 0},
+	{"ab", "ab", 0, 0, 0},
+	{"a", "", 1, 1, 1},
+	{"aa", "a", 1, 1, 1},
+	{"aaa", "a", 2, 2, 2},
+	{"ab", "ba", 2, 1, 2},
+	{"typo", "tyop", 2, 1, 2},
+}
+
+func checkDistance(t *testing.T, name, source, target string, correctDistance int, ops []EditOperation) {
+	distance := DistanceForStrings([]rune(source), []rune(target), ops)
+
+	if distance != correctDistance {
+		t.Log(
+			name,
+			"distance between",
+			source,
+			"and",
+			target,
+			"computed as",
+			distance,
+			", should be",
+			correctDistance)
+		t.Fail()
+	}
 }
 
 func TestDistanceForStrings(t *testing.T) {
 	for _, testCase := range testCases {
-		distance := DistanceForStrings(
-			[]rune(testCase.source),
-			[]rune(testCase.target),
-			DefaultOptions)
-		if distance != testCase.distance {
-			t.Log(
-				"Distance between",
-				testCase.source,
-				"and",
-				testCase.target,
-				"computed as",
-				distance,
-				", should be",
-				testCase.distance)
-			t.Fail()
-		}
+		checkDistance(t, "Levenshtein", testCase.source, testCase.target, testCase.distance, DefaultLevenshtein)
+		checkDistance(t, "Damerau", testCase.source, testCase.target, testCase.damerauDistance, DefaultDamerau)
+		checkDistance(t, "LCS", testCase.source, testCase.target, testCase.lcsDistance, DefaultLCS)
 	}
 }
 
 func ExampleDistanceForStrings() {
 	source := "a"
 	target := "aa"
-	distance := DistanceForStrings([]rune(source), []rune(target), DefaultOptions)
+	distance := DistanceForStrings([]rune(source), []rune(target), DefaultLevenshtein)
 	fmt.Printf(`Distance between "%s" and "%s" computed as %d`, source, target, distance)
 	// Output: Distance between "a" and "aa" computed as 1
 }
@@ -57,7 +66,15 @@ func ExampleDistanceForStrings() {
 func ExampleWriteMatrix() {
 	source := []rune("neighbor")
 	target := []rune("Neighbour")
-	matrix := MatrixForStrings(source, target, DefaultOptions)
+
+	ops := []EditOperation{
+		Match{},
+		Insertion{1},
+		Deletion{1},
+		Substitution{2},
+	}
+
+	matrix := MatrixForStrings(source, target, ops)
 	WriteMatrix(source, target, matrix, os.Stdout)
 	// Output:
 	//       N  e  i  g  h  b  o  u  r

--- a/levenshtein/operations.go
+++ b/levenshtein/operations.go
@@ -1,0 +1,126 @@
+package levenshtein
+
+import "fmt"
+
+type EditScript []EditOperation
+
+type EditOperation interface {
+	fmt.Stringer
+	Apply(source, target []rune, matrix [][]int, i, j int) (int, bool)
+	Backtrack(matrix [][]int, i, j int) (int, int)
+}
+
+var _ EditOperation = &Insertion{}
+
+var _ EditOperation = &Match{}
+
+type Match struct {
+}
+
+func (o Match) Apply(source, target []rune, matrix [][]int, i, j int) (int, bool) {
+	if i > 0 && j > 0 && source[i-1] == target[j-1] {
+		return matrix[i-1][j-1], true
+	}
+
+	return 0, false
+}
+
+func (o Match) Backtrack(matrix [][]int, i, j int) (int, int) {
+	return i - 1, j - 1
+}
+
+func (o Match) String() string {
+	return "match"
+}
+
+type Insertion struct {
+	Cost int
+}
+
+func (o Insertion) Apply(source, target []rune, matrix [][]int, i, j int) (int, bool) {
+	if j > 0 {
+		return matrix[i][j-1] + o.Cost, true
+	}
+
+	return 0, false
+}
+
+func (o Insertion) Backtrack(matrix [][]int, i, j int) (int, int) {
+	return i, j - 1
+}
+
+func (o Insertion) String() string {
+	return "ins"
+}
+
+var _ EditOperation = &Deletion{}
+
+type Deletion struct {
+	Cost int
+}
+
+func (o Deletion) Apply(source, target []rune, matrix [][]int, i, j int) (int, bool) {
+	if i > 0 {
+		return matrix[i-1][j] + o.Cost, true
+	}
+
+	return 0, false
+}
+
+func (o Deletion) Backtrack(matrix [][]int, i, j int) (int, int) {
+	return i - 1, j
+}
+
+func (o Deletion) String() string {
+	return "del"
+}
+
+var _ EditOperation = &Substitution{}
+
+type Substitution struct {
+	Cost int
+}
+
+func (o Substitution) Apply(source, target []rune, matrix [][]int, i, j int) (int, bool) {
+	if i > 0 && j > 0 {
+		return matrix[i-1][j-1] + o.Cost, true
+	}
+
+	return 0, false
+}
+
+func (o Substitution) Backtrack(matrix [][]int, i, j int) (int, int) {
+	return i - 1, j - 1
+}
+
+func (o Substitution) String() string {
+	return "del"
+}
+
+var _ EditOperation = &Transposition{}
+
+type Transposition struct {
+	Cost int
+}
+
+func (o Transposition) Apply(source, target []rune, matrix [][]int, i, j int) (int, bool) {
+	if i > 1 && j > 1 {
+		if source == nil && target == nil {
+			return matrix[i-2][j-2] + o.Cost, true
+		}
+
+		if source[i-1] == target[j-2] && source[i-2] == target[j-1] {
+			return matrix[i-2][j-2] + o.Cost, true
+		}
+	}
+
+	return 0, false
+}
+
+func (o Transposition) Backtrack(matrix [][]int, i, j int) (int, int) {
+	return i - 2, j - 2
+}
+
+func (o Transposition) String() string {
+	return "trp"
+}


### PR DESCRIPTION
The operations are factored out as separate types, making the dynamic
programming algorithm completely generic. As a result, you can define
custom edit distances, e.g.:

lcs := []EditOperation{
    Match{},
    Insertion{1},
    Deletion{1},
}

New kinds of edit operations can also be added, by implementing the
EditOperation interface (assuming that they work in dynamic programming).
