### PR TITLE
Memory efficient DistanceForStrings

### DIFF
--- a/levenshtein/levenshtein.go
+++ b/levenshtein/levenshtein.go
@@ -58,19 +58,8 @@ func (operation EditOperation) String() string {
 // DistanceForStrings returns the edit distance between source and target.
 //
 // It has a runtime proportional to len(source) * len(target) and memory use
-// proportional to min(len(source), len(target)).
+// proportional to len(target).
 func DistanceForStrings(source []rune, target []rune, op Options) int {
-	// Our memory use is proportional to the size of target, so ensure target is the smaller.
-	if len(target) > len(source) {
-		target, source = source, target
-		op = Options{
-			InsCost: op.DelCost,
-			DelCost: op.InsCost,
-			SubCost: op.SubCost,
-			Matches: op.Matches, // TODO This assumes Matches is commutative and pure
-		}
-	}
-
 	// We only use the current and previous row, so the matrix height is only 2.
 	height := len(source) + 1
 	width := len(target) + 1

--- a/levenshtein/levenshtein.go
+++ b/levenshtein/levenshtein.go
@@ -60,7 +60,11 @@ func (operation EditOperation) String() string {
 // It has a runtime proportional to len(source) * len(target) and memory use
 // proportional to len(target).
 func DistanceForStrings(source []rune, target []rune, op Options) int {
-	// We only use the current and previous row, so the matrix height is only 2.
+	// Note: This algorithm is a specialization of MatrixForStrings.
+	// MatrixForStrings returns the full edit matrix. However, we only need a
+	// single value (see DistanceForMatrix) and the main loop of the algorithm
+	// only uses the current and previous row. As such we create a 2D matrix,
+	// but with height 2 (enough to store current and previous row).
 	height := len(source) + 1
 	width := len(target) + 1
 	matrix := make([][]int, 2)

--- a/levenshtein/levenshtein_test.go
+++ b/levenshtein/levenshtein_test.go
@@ -134,6 +134,24 @@ func TestDistanceForStrings(t *testing.T) {
 				testCase.distance)
 			t.Fail()
 		}
+		// DistanceForMatrix(MatrixForStrings()) should calculate the same
+		// value as DistanceForStrings.
+		distance = DistanceForMatrix(MatrixForStrings(
+			[]rune(testCase.source),
+			[]rune(testCase.target),
+			DefaultOptions))
+		if distance != testCase.distance {
+			t.Log(
+				"Distance between",
+				testCase.source,
+				"and",
+				testCase.target,
+				"computed as",
+				distance,
+				", should be",
+				testCase.distance)
+			t.Fail()
+		}
 	}
 }
 


### PR DESCRIPTION
`DistanceForStrings` previously computed the entire edit matrix, but only used
the last entry in the matrix. Given the loop of the edit matrix algorithm only
uses the current row and the previous, we only need to store 2 rows of the edit
matrix to calculate the same value. This reduces memory consumption from `O(nm)`
to `O(n)`.

This implementation also transforms the input such that we get the smallest
possible row. This further reduces memory consumption to `O(min(n,m))`.